### PR TITLE
Implement console-style log viewer

### DIFF
--- a/KixDutyFree.App/Pages/LogViewer.razor
+++ b/KixDutyFree.App/Pages/LogViewer.razor
@@ -1,4 +1,4 @@
-﻿@page "/logs"
+@page "/logs"
 @using KixDutyFree.App.Service
 @using Serilog.Events
 @inject LogStore LogStore
@@ -8,127 +8,116 @@
 <PageTitle>日志</PageTitle>
 
 <MContainer Fluid>
-    <MDataTable Id="logViewTable" Stripe Loading="@Loading" Items="logEvents" Headers="_headers" Page="@_page"
-        ItemsPerPage="@_itemsPerPage"
-        HideDefaultFooter
-        OnOptionsUpdate="@HandleOnOptionsUpdate"
-        ServerItemsLength="@_total" Class="elevation-1">
-        <TopContent>
-            <MToolbar>
-                <MToolbarTitle>日志列表</MToolbarTitle>
-            </MToolbar>
-        </TopContent>
-        <ItemColContent>
-            @if (context.Header.Value == "Level")
-            {
-                switch (context.Item.Level)
+    <MCard>
+        <MCardTitle>日志</MCardTitle>
+        <MCardText>
+            <div class="log-console" @ref="scrollContainer">
+                @foreach (var item in logEvents.OrderBy(e => e.Timestamp))
                 {
-                    case LogEventLevel.Information:
-                        <MChip Class="ma-2" Color="success" Label>
-                            @context.Item.Level
-                        </MChip>
-                        break;
-                    case LogEventLevel.Warning:
-                        <MChip Class="ma-2"
-                        Color="warning"
-                        Label>
-                            @context.Item.Level
-                        </MChip>
-                        break;
-                    case LogEventLevel.Error:
-                        <MChip Class="ma-2"
-                        Color="error"
-                        Label>
-                            @context.Item.Level
-                        </MChip>
-                        break;
-                    default:
-                        <MChip Class="ma-2"
-                        Label>
-                            @context.Item.Level
-                        </MChip>
-                        break;
+                    <div class="@GetLevelClass(item.Level)">
+                        [@item.Timestamp.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss:fff")] @item.Level - @item.RenderMessage()
+                        @if (item.Exception != null)
+                        {
+                            <br />
+                            @item.Exception
+                        }
+                    </div>
                 }
-            }
-            else
-            {
-                @context.Value
-            }
-        </ItemColContent>
-    </MDataTable>
+            </div>
+        </MCardText>
+    </MCard>
 </MContainer>
+
+<style>
+    .log-console {
+        height: 400px;
+        overflow-y: auto;
+        font-family: monospace;
+        background-color: #1e1e1e;
+        color: #ffffff;
+        padding: 10px;
+    }
+
+    .log-info {
+        color: #00ff00;
+    }
+
+    .log-warning {
+        color: #ffff00;
+    }
+
+    .log-error {
+        color: #ff5555;
+    }
+</style>
+
 @code {
+    /// <summary>
+    /// 日志事件集合
+    /// </summary>
     private List<LogEvent> logEvents = new();
 
+    /// <summary>
+    /// 日志容器引用
+    /// </summary>
     private ElementReference scrollContainer;
 
+    /// <summary>
+    /// 定时器用于定时刷新日志
+    /// </summary>
     private System.Threading.Timer? _timer;
 
-    private int _total;
+    /// <summary>
+    /// 刷新时间间隔
+    /// </summary>
+    private readonly TimeSpan _refreshInterval = TimeSpan.FromSeconds(2);
 
-    private int _itemsPerPage = 50;
-
-    private int _page = 1;
-
-    private DataOptions _options = new(1, 50);
-
-    private bool Loading = false;
-
-    private string height = "100%";
-
-    private readonly TimeSpan _refreshInterval = TimeSpan.FromSeconds(2); // 设置刷新间隔
-
-    private List<DataTableHeader<LogEvent>> _headers = new List<DataTableHeader<LogEvent>>
-        {
-          new (){ Text= "时间",Align= DataTableHeaderAlign.Center, Value= "Timestamp",Width = 220, CellRender = dessert => dessert.Timestamp.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss:fff"),Fixed = DataTableFixed.Left},
-          new (){ Text= "级别", Align= DataTableHeaderAlign.Center, Value= "Level",Width = 220,Fixed = DataTableFixed.Left},
-          new (){ Text= "消息",Align= DataTableHeaderAlign.Center, Value= "Message",CellRender =  dessert => dessert.RenderMessage()},
-          new (){
-              Text= "异常",
-              Align= DataTableHeaderAlign.Center,
-              Value= "Exception",
-              CellRender = dessert => dessert.Exception?.ToString() ?? "-"}
-        };
-
+    /// <summary>
+    /// 初始化设置定时器
+    /// </summary>
     protected override void OnInitialized()
     {
-        // // 初始加载日志
-        // LoadLogEvents();
-        // 设置定时器
         _timer = new System.Threading.Timer(_ =>
         {
-            LoadLogEvents(_page, _itemsPerPage);
-
+            LoadLogEvents();
         }, null, TimeSpan.Zero, _refreshInterval);
     }
 
-    private void HandleOnOptionsUpdate(DataOptions options)
+    /// <summary>
+    /// 加载日志并滚动到底部
+    /// </summary>
+    private void LoadLogEvents()
     {
-        _options = options;
-        _page = options.Page;
-        _itemsPerPage = _options.ItemsPerPage;
-        LoadLogEvents(_options.Page, _options.ItemsPerPage);
+        var data = LogStore.GetLogEvents(1, 500);
+        logEvents = data.List.OrderBy(e => e.Timestamp).ToList();
+        InvokeAsync(async () =>
+        {
+            await JSRuntime.InvokeVoidAsync("scrollToBottom", scrollContainer);
+            StateHasChanged();
+        });
     }
 
-
-    private void LoadLogEvents(int pageNum, int pageSize)
+    /// <summary>
+    /// 获取日志级别样式
+    /// </summary>
+    /// <param name="level">日志级别</param>
+    /// <returns>样式名称</returns>
+    private string GetLevelClass(LogEventLevel level)
     {
-        Loading = true;
-        // 获取并排序日志事件
-        var data = LogStore.GetLogEvents(pageNum, pageSize);
-        logEvents = data.List;
-        _total = data.Total;
-        // 更新 UI 并滚动到最底部
-        InvokeAsync(() =>
-       {
-           StateHasChanged();
-       });
-        Loading = false;
+        return level switch
+        {
+            LogEventLevel.Information => "log-info",
+            LogEventLevel.Warning => "log-warning",
+            LogEventLevel.Error => "log-error",
+            _ => string.Empty
+        };
     }
 
+    /// <summary>
+    /// 释放定时器
+    /// </summary>
     public void Dispose()
     {
-        // 停止并释放定时器
         _timer?.Dispose();
     }
 }

--- a/KixDutyFree.App/wwwroot/index.html
+++ b/KixDutyFree.App/wwwroot/index.html
@@ -69,6 +69,7 @@
 
     <script src="_framework/blazor.webview.js"></script>
     <script src="_content/Masa.Blazor/js/masa-blazor.js"></script>
+    <script src="js/logViewer.js"></script>
     <script>
         (function () {
             document.addEventListener('mousedown', async function (event) {

--- a/KixDutyFree.App/wwwroot/js/logViewer.js
+++ b/KixDutyFree.App/wwwroot/js/logViewer.js
@@ -1,0 +1,5 @@
+function scrollToBottom(element) {
+    if (element) {
+        element.scrollTop = element.scrollHeight;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@
 - 添加Masa Blazor组件
 - HandyControl实现windows托盘图标
 - HtmlAgilityPack + HttpClient 解析网页元素
+- 优化日志查看页面，采用控制台风格展示日志
+
+更新时间: 2025-06-30 11:19:55
+


### PR DESCRIPTION
## Summary
- remove data table log viewer and implement console style
- add helper JS for auto-scroll
- link new script in index
- document update in README

## Testing
- `dotnet restore` *(fails: NETSDK1045)*
- `dotnet build -c Release /warnaserror` *(fails: NETSDK1045)*
- `dotnet format --verify-no-changes` *(fails: Restore operation failed)*
- `dotnet tool run dotnet-reportgenerator` *(fails: tool not found)*

------
https://chatgpt.com/codex/tasks/task_e_686201b394748323909bfd526fd3f848